### PR TITLE
Feature/automate go binary release

### DIFF
--- a/.github/workflows/build-release-binary.yml
+++ b/.github/workflows/build-release-binary.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: GCC multilib
+        run: sudo apt-get install gcc-multilib g++-multilib
+
       - name: Conditionally set environment variables for compilation
         if: ${{ matrix.goos == 'windows' }}
         run: CC="x86_64-w64-mingw32-gcc"

--- a/.github/workflows/build-release-binary.yml
+++ b/.github/workflows/build-release-binary.yml
@@ -11,6 +11,12 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
+      - name: OSXCross for CGO Support
+        run: |
+          mkdir ../../osxcross
+          git clone https://github.com/plentico/osxcross-target.git ../../osxcross/target
+
       - name: Set up Go
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/build-release-binary.yml
+++ b/.github/workflows/build-release-binary.yml
@@ -25,11 +25,8 @@ jobs:
 
       - name: OSXCross for CGO Support
         run: |
-          mkdir ../../osxcross
-          git clone https://github.com/plentico/osxcross-target.git ../../osxcross/target
-          ls ../../osxcross/target
-          ls ../../osxcross/target/bin
-          ls /usr/bin | grep mingw
+          mkdir /home/runner/work/osxcross
+          git clone https://github.com/plentico/osxcross-target.git /home/runner/work/osxcross/target
 
       - name: Set windows compiler
         if: ${{ matrix.goos == 'windows' }}

--- a/.github/workflows/build-release-binary.yml
+++ b/.github/workflows/build-release-binary.yml
@@ -21,7 +21,12 @@ jobs:
         uses: actions/checkout@v2
 
       - name: GCC multilib
-        run: sudo apt update && sudo apt install gcc-multilib g++-multilib mingw-w64 clang-12
+        run: sudo apt update && sudo apt install gcc-multilib g++-multilib gcc-mingw-w64 clang-12
+
+      - name: OSXCross for CGO Support
+        run: |
+          mkdir ../../osxcross
+          git clone https://github.com/plentico/osxcross-target.git ../../osxcross/target
 
       - name: Set windows compiler
         if: ${{ matrix.goos == 'windows' }}
@@ -31,12 +36,12 @@ jobs:
       - name: Set darwin compiler amd64
         if: ${{ matrix.goos == 'darwin' && matrix.goarch == 'amd64' }}
         run: |
-          echo CC="o64-clang" >> $GITHUB_ENV
+          echo CC="/home/runner/work/osxcross/target/bin/o64-clang" >> $GITHUB_ENV
       
       - name: Set darwin compiler arm64
         if: ${{ matrix.goos == 'darwin' && matrix.goarch == 'arm64' }}
         run: |
-          echo CC="aarch64-apple-darwin20.2-clang" >> $GITHUB_ENV
+          echo CC="/home/runner/work/osxcross/target/bin/aarch64-apple-darwin20.4-clang" >> $GITHUB_ENV
 
       - name: Go Build Release
         env:

--- a/.github/workflows/build-release-binary.yml
+++ b/.github/workflows/build-release-binary.yml
@@ -5,7 +5,7 @@ on:
 name: Build and Release Go Binaries
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04 #https://githubmemory.com/repo/plentico/plenti/issues/148
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/build-release-binary.yml
+++ b/.github/workflows/build-release-binary.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: GCC multilib
-        run: sudo apt-get install gcc-multilib g++-multilib mingw-64 clang-12
+        run: sudo apt update && sudo apt install gcc-multilib g++-multilib mingw-w64 clang-12
 
       - name: Set windows compiler
         if: ${{ matrix.goos == 'windows' }}

--- a/.github/workflows/build-release-binary.yml
+++ b/.github/workflows/build-release-binary.yml
@@ -1,0 +1,35 @@
+on:
+  release:
+    types: [created]
+
+name: Build and Release Go Binaries
+jobs:
+  buildReleaseBinaries:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # build and publish in for multiple machine architectures in parallel:
+        goos: [linux, windows, darwin]
+        goarch: [amd64, arm64]
+        exclude:
+          # exclude this combo as results in unsupported GOOS/GOARCH pair windows/arm64
+          - goos: windows
+            goarch: arm64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Go Build Release
+        env:
+          # required for sqlite drivers
+          CGO_ENABLED: 1
+          CGO_CFLAGS_ALLOW: "-Xpreprocessor"
+        uses: wangyoucao577/go-release-action@v1.20
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          goos: ${{ matrix.goos }}
+          goarch: ${{ matrix.goarch }}
+          goversion: 1.16
+          project_path: "./backend"
+          binary_name: "sheetable"

--- a/.github/workflows/build-release-binary.yml
+++ b/.github/workflows/build-release-binary.yml
@@ -5,12 +5,19 @@ on:
 name: Build and Release Go Binaries
 jobs:
   goreleaser:
-    runs-on: ubuntu-18.04 #https://githubmemory.com/repo/plentico/plenti/issues/148
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
+      # https://githubmemory.com/repo/plentico/osxcross-target/issues/2
+      - name: Downgrade libssl
+        run: |
+          echo 'deb http://security.ubuntu.com/ubuntu bionic-security main' | sudo tee -a /etc/apt/sources.list
+          sudo apt update && apt-cache policy libssl1.0-dev
+          sudo apt-get install libssl1.0-dev
 
       - name: OSXCross for CGO Support
         run: |

--- a/.github/workflows/build-release-binary.yml
+++ b/.github/workflows/build-release-binary.yml
@@ -21,5 +21,6 @@ jobs:
           distribution: goreleaser
           version: latest
           args: release --rm-dist
+          workdir: ./backend
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-release-binary.yml
+++ b/.github/workflows/build-release-binary.yml
@@ -29,6 +29,7 @@ jobs:
           # required for sqlite drivers
           CGO_ENABLED: 1
           CGO_CFLAGS_ALLOW: "-Xpreprocessor"
+          CC: ${{env.CC}}
         uses: wangyoucao577/go-release-action@v1.20
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-release-binary.yml
+++ b/.github/workflows/build-release-binary.yml
@@ -18,6 +18,10 @@ jobs:
           echo 'deb http://security.ubuntu.com/ubuntu bionic-security main' | sudo tee -a /etc/apt/sources.list
           sudo apt update && apt-cache policy libssl1.0-dev
           sudo apt-get install libssl1.0-dev
+      
+      - name: Install compiler for windows
+        run: |
+          sudo apt install gcc-mingw-w64
 
       - name: OSXCross for CGO Support
         run: |

--- a/.github/workflows/build-release-binary.yml
+++ b/.github/workflows/build-release-binary.yml
@@ -20,6 +20,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Conditionally set environment variables for compilation
+        if: ${{ matrix.goos == 'windows' }}
+        run: CC="x86_64-w64-mingw32-gcc"
+
       - name: Go Build Release
         env:
           # required for sqlite drivers

--- a/.github/workflows/build-release-binary.yml
+++ b/.github/workflows/build-release-binary.yml
@@ -25,15 +25,18 @@ jobs:
 
       - name: Set windows compiler
         if: ${{ matrix.goos == 'windows' }}
-        run: CC="x86_64-w64-mingw32-gcc"
+        run: |
+          echo CC="x86_64-w64-mingw32-gcc" >> $GITHUB_ENV
 
       - name: Set darwin compiler amd64
         if: ${{ matrix.goos == 'darwin' && matrix.goarch == 'amd64' }}
-        run: CC=o64-clang
+        run: |
+          echo CC="o64-clang" >> $GITHUB_ENV
       
       - name: Set darwin compiler arm64
         if: ${{ matrix.goos == 'darwin' && matrix.goarch == 'arm64' }}
-        run: CC=aarch64-apple-darwin20.2-clang
+        run: |
+          echo CC="aarch64-apple-darwin20.2-clang" >> $GITHUB_ENV
 
       - name: Go Build Release
         env:

--- a/.github/workflows/build-release-binary.yml
+++ b/.github/workflows/build-release-binary.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: GCC multilib
-        run: sudo apt-get install gcc-multilib g++-multilib
+        run: sudo apt-get install gcc-multilib g++-multilib gcc_mingw64 clang-12
 
       - name: Set windows compiler
         if: ${{ matrix.goos == 'windows' }}

--- a/.github/workflows/build-release-binary.yml
+++ b/.github/workflows/build-release-binary.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: GCC multilib
-        run: sudo apt-get install gcc-multilib g++-multilib gcc_mingw64 clang-12
+        run: sudo apt-get install gcc-multilib g++-multilib mingw-64 clang-12
 
       - name: Set windows compiler
         if: ${{ matrix.goos == 'windows' }}

--- a/.github/workflows/build-release-binary.yml
+++ b/.github/workflows/build-release-binary.yml
@@ -23,9 +23,17 @@ jobs:
       - name: GCC multilib
         run: sudo apt-get install gcc-multilib g++-multilib
 
-      - name: Conditionally set environment variables for compilation
+      - name: Set windows compiler
         if: ${{ matrix.goos == 'windows' }}
         run: CC="x86_64-w64-mingw32-gcc"
+
+      - name: Set darwin compiler amd64
+        if: ${{ matrix.goos == 'darwin' && matrix.goarch == 'amd64' }}
+        run: CC=o64-clang
+      
+      - name: Set darwin compiler arm64
+        if: ${{ matrix.goos == 'darwin' && matrix.goarch == 'arm64' }}
+        run: CC=aarch64-apple-darwin20.2-clang
 
       - name: Go Build Release
         env:

--- a/.github/workflows/build-release-binary.yml
+++ b/.github/workflows/build-release-binary.yml
@@ -4,56 +4,22 @@ on:
 
 name: Build and Release Go Binaries
 jobs:
-  buildReleaseBinaries:
+  goreleaser:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        # build and publish in for multiple machine architectures in parallel:
-        goos: [linux, windows, darwin]
-        goarch: [amd64, arm64]
-        exclude:
-          # exclude this combo as results in unsupported GOOS/GOARCH pair windows/arm64
-          - goos: windows
-            goarch: arm64
-
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      - name: GCC multilib
-        run: sudo apt update && sudo apt install gcc-multilib g++-multilib gcc-mingw-w64 clang-12
-
-      - name: OSXCross for CGO Support
-        run: |
-          mkdir /home/runner/work/osxcross
-          git clone https://github.com/plentico/osxcross-target.git /home/runner/work/osxcross/target
-
-      - name: Set windows compiler
-        if: ${{ matrix.goos == 'windows' }}
-        run: |
-          echo CC="x86_64-w64-mingw32-gcc" >> $GITHUB_ENV
-
-      - name: Set darwin compiler amd64
-        if: ${{ matrix.goos == 'darwin' && matrix.goarch == 'amd64' }}
-        run: |
-          echo CC="/home/runner/work/osxcross/target/bin/o64-clang" >> $GITHUB_ENV
-      
-      - name: Set darwin compiler arm64
-        if: ${{ matrix.goos == 'darwin' && matrix.goarch == 'arm64' }}
-        run: |
-          echo CC="/home/runner/work/osxcross/target/bin/aarch64-apple-darwin20.4-clang" >> $GITHUB_ENV
-
-      - name: Go Build Release
-        env:
-          # required for sqlite drivers
-          CGO_ENABLED: 1
-          CGO_CFLAGS_ALLOW: "-Xpreprocessor"
-          CC: ${{env.CC}}
-        uses: wangyoucao577/go-release-action@v1.20
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          goos: ${{ matrix.goos }}
-          goarch: ${{ matrix.goarch }}
-          goversion: 1.16
-          project_path: "./backend"
-          binary_name: "sheetable"
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-release-binary.yml
+++ b/.github/workflows/build-release-binary.yml
@@ -27,6 +27,9 @@ jobs:
         run: |
           mkdir ../../osxcross
           git clone https://github.com/plentico/osxcross-target.git ../../osxcross/target
+          ls ../../osxcross/target
+          ls ../../osxcross/target/bin
+          ls /usr/bin | grep mingw
 
       - name: Set windows compiler
         if: ${{ matrix.goos == 'windows' }}

--- a/backend/.goreleaser.yml
+++ b/backend/.goreleaser.yml
@@ -1,5 +1,6 @@
 builds:
 - id: linux-build
+  binary: sheetable
   env:
   - CGO_ENABLED=1
   goos:
@@ -10,6 +11,7 @@ builds:
   - goos: linux
     goarch: arm64
 - id: darwin-build
+  binary: sheetable
   ldflags:
   - -s
   env:
@@ -21,3 +23,17 @@ builds:
   ignore:
   - goos: darwin
     goarch: 386
+- id: windows-build
+  binary: sheetable
+  ldflags: -buildmode=exe
+  env:
+    - CGO_ENABLED=1
+    - CC=x86_64-w64-mingw32-gcc
+    - CXX=x86_64-w64-mingw32-g++
+  goos:
+    - windows
+  goarch:
+    - amd64
+
+changelog:
+  skip: true

--- a/backend/.goreleaser.yml
+++ b/backend/.goreleaser.yml
@@ -1,0 +1,21 @@
+builds:
+- id: linux-build
+  env:
+  - CGO_ENABLED=1
+  goos:
+  - linux
+  ignore:
+  - goos: linux
+    goarch: 386
+- id: darwin-build
+  ldflags:
+  - -s
+  env:
+  - CGO_ENABLED=1
+  - CC=/home/runner/work/osxcross/target/bin/o64-clang
+  - CXX=/home/runner/work/osxcross/target/bin/o64-clang++
+  goos:
+  - darwin
+  ignore:
+  - goos: darwin
+    goarch: 386

--- a/backend/.goreleaser.yml
+++ b/backend/.goreleaser.yml
@@ -7,6 +7,8 @@ builds:
   ignore:
   - goos: linux
     goarch: 386
+  - goos: linux
+    goarch: arm64
 - id: darwin-build
   ldflags:
   - -s


### PR DESCRIPTION
# Pull Request Template

## Description

Adds a new workflow which automatically builds and releases Go binaries when a release is created.  
It is triggered when a release is created and once it finishes running it will upload the binaries as assets to that release once it has finished.

See the mock release I made in my fork of the repo for the output [here](https://github.com/jj-style/SheetAble/releases/tag/v1.0)
Note: I have tested running the linux binary that was built and that worked. I don't have a mac/windows machine to hand so couldn't test if they ran okay.

Fixes #11 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
