### PR TITLE
Reformat the comments in backend

### DIFF
--- a/backend/api/auth/token.go
+++ b/backend/api/auth/token.go
@@ -12,7 +12,7 @@ func CreateToken(user_id uint32, apiSecret string) (string, error) {
 	claims := jwt.MapClaims{}
 	claims["authorized"] = true
 	claims["user_id"] = user_id
-	claims["exp"] = time.Now().Add(time.Hour * 168).Unix() //Token expires after 1 week
+	claims["exp"] = time.Now().Add(time.Hour * 168).Unix() // Token expires after 1 week
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	return token.SignedString([]byte(apiSecret))
 

--- a/backend/api/controllers/base.go
+++ b/backend/api/controllers/base.go
@@ -16,8 +16,8 @@ import (
 
 	"github.com/SheetAble/SheetAble/backend/api/models"
 	"github.com/gorilla/handlers"
-	_ "github.com/jinzhu/gorm/dialects/mysql"    //mysql database driver
-	_ "github.com/jinzhu/gorm/dialects/postgres" //postgres database driver
+	_ "github.com/jinzhu/gorm/dialects/mysql"    // mysql database driver
+	_ "github.com/jinzhu/gorm/dialects/postgres" // postgres database driver
 	_ "github.com/jinzhu/gorm/dialects/sqlite"
 )
 
@@ -30,7 +30,7 @@ func (server *Server) Initialize() {
 
 	var err error
 
-	/* Set Release Mode */
+	// Set Release Mode
 	if !Config().Dev {
 		gin.SetMode(gin.ReleaseMode)
 	}
@@ -73,10 +73,10 @@ func (server *Server) Initialize() {
 		}
 	}
 
-	/* Silence the logger */
+	// Silence the logger
 	server.DB.LogMode(false)
 
-	/* Migrate DBs */
+	// Migrate DBs
 	server.DB.AutoMigrate(&models.User{}, &models.Sheet{})
 
 	server.SetupRouter()
@@ -84,10 +84,11 @@ func (server *Server) Initialize() {
 
 func (server *Server) Run(addr string, dev bool) {
 	fmt.Printf("Listening to port %v\n", addr)
-	// cors.Default() setup the middleware with default options being
-	// all origins accepted with simple methods (GET, POST). See
-	// documentation below for more options.
-
+	/* 
+		cors.Default() setup the middleware with default options being
+		all origins accepted with simple methods (GET, POST).
+		See documentation below for more options.
+	*/
 	c := cors.New(cors.Options{
 		// Enable Debugging for testing, consider disabling in production
 		AllowedHeaders: []string{
@@ -108,7 +109,7 @@ func (server *Server) Run(addr string, dev bool) {
 		AllowCredentials: true,
 	})
 
-	/* Check if run in dev mode, so you can enable CORS or not */
+	// Check if run in dev mode, so you can enable CORS or not 
 	srvHandler := handlers.LoggingHandler(os.Stdout, c.Handler(server.Router))
 
 	if !dev {

--- a/backend/api/controllers/composers_controller.go
+++ b/backend/api/controllers/composers_controller.go
@@ -117,7 +117,8 @@ func (server *Server) DeleteComposer(c *gin.Context) {
 	c.JSON(http.StatusOK, "Composer deleted successfully")
 }
 
-/*	Serve the Composer Portraits
+/*	
+	Serve the Composer Portraits
 	Example request:
 		GET /composer/portrait/Chopin
 */
@@ -127,10 +128,12 @@ func (server *Server) ServePortraits(c *gin.Context) {
 	c.File(filePath)
 }
 
-/*	Upload a portrait
+/*	
+	Upload a portrait
 	! Currently only PNG files supported
 */
 func uploadPortait(portrait multipart.File, compName string, originalName string) bool {
+	
 	// Create the composer Directory if it doesn't exist yet
 	dir := path.Join(Config().ConfigPath, "composer")
 	fullpath := path.Join(dir, sanitize.Name(compName)+".png")

--- a/backend/api/controllers/routes.go
+++ b/backend/api/controllers/routes.go
@@ -15,7 +15,7 @@ func (server *Server) SetupRouter() {
 	r := gin.New()
 	r.Use(gin.Recovery())
 
-	// health checks
+	// Health checks
 	r.GET("/health", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"status": "OK"})
 	})
@@ -24,7 +24,7 @@ func (server *Server) SetupRouter() {
 
 	api.GET("", server.Home)
 
-	// secureApi is still rooted at /api/... but it has the auth middleware so it'server routes check token on each call
+	// SecureApi is still rooted at /api/... but it has the auth middleware so it'server routes check token on each call
 	secureApi := api.Group("")
 	secureApi.Use(middlewares.AuthMiddleware())
 
@@ -66,7 +66,7 @@ func (server *Server) SetupRouter() {
 	// Serve React
 	appBox := rice.MustFindBox("../../../frontend/build")
 
-	//r.StaticFS("/static", appBox.HTTPBox())
+	// r.StaticFS("/static", appBox.HTTPBox())
 	r.GET("/static/*filepath", func(c *gin.Context) {
 		filepath := c.Request.URL.String()
 		file, err := appBox.Open(filepath)

--- a/backend/api/controllers/sheet_controller.go
+++ b/backend/api/controllers/sheet_controller.go
@@ -50,7 +50,8 @@ func (server *Server) GetSheetsPage(c *gin.Context) {
 	c.JSON(http.StatusOK, pageNew)
 }
 
-/*	Get PDF file and information about an individual sheet.
+/*	
+	Get PDF file and information about an individual sheet.
 	Example request:
 		GET /sheet/Étude N. 1
 	Has to be safeName
@@ -94,9 +95,8 @@ func (server *Server) GetThumbnail(c *gin.Context) {
 	c.File(filePath)
 }
 
-/*
-	Has to be safeName of the sheet
-*/
+
+// Has to be safeName of the sheet
 func (server *Server) DeleteSheet(c *gin.Context) {
 	sheetName := c.Param("sheetName")
 
@@ -159,7 +159,6 @@ func (server *Server) AppendTag(c *gin.Context) {
 		POST /api/tag/sheet/fuer-elise
 			Body (FormValue):
 			- tagValue: New Tag
-
 	*/
 
 	sheet := getSheet(server.DB, c)
@@ -230,10 +229,8 @@ func (server *Server) UpdateSheetInformationText(c *gin.Context) {
 }
 
 func getSheet(db *gorm.DB, c *gin.Context) *models.Sheet {
-	/*
-		Find a sheet by its name
-	*/
-
+	
+	// Find a sheet by its name
 	sheetName := c.Param("sheetName")
 	if sheetName == "" {
 		utils.DoError(c, http.StatusBadRequest, errors.New("missing URL parameter 'sheetName'"))

--- a/backend/api/controllers/uploader.go
+++ b/backend/api/controllers/uploader.go
@@ -1,7 +1,7 @@
 /*
 	This file is for handeling the basic upload of sheets.
 	It will upload given file in the uploaded sheets folder either under
-	the unknown subfolder or under the author's name subfolder, depending on wheter an author is given or not.
+	the unknown subfolder or under the author's name subfolder, depending on whether an author is given or not.
 */
 
 package controllers
@@ -28,9 +28,9 @@ import (
 	"github.com/kennygrant/sanitize"
 )
 
-/*
-	Structs for handling the response on the Open Opus API
-*/
+
+// Structs for handling the response on the Open Opus API
+
 
 type Response struct {
 	Composers *[]Comp `json: "composers"`
@@ -106,7 +106,7 @@ func (server *Server) UploadFile(c *gin.Context) {
 		return
 	}
 
-	// return that we have successfully uploaded our file!
+	// Return that we have successfully uploaded our file!
 	c.JSON(http.StatusAccepted, "File uploaded successfully")
 }
 
@@ -159,9 +159,8 @@ func getPortraitURL(composerName string) Comp {
 	err_new := json.Unmarshal([]byte(string(body)), response)
 	fmt.Println(err_new)
 	composers := *response.Composers
-	/*
-		Check if the given name and the name from the API are alike
-	*/
+	
+	// Check if the given name and the name from the API are alike
 	if len(composers) == 0 || (!strings.EqualFold(composerName, composers[0].Name) && !strings.EqualFold(composerName, composers[0].CompleteName)) {
 		return Comp{
 			CompleteName: composerName,

--- a/backend/api/forms/upload.go
+++ b/backend/api/forms/upload.go
@@ -12,10 +12,9 @@ type UploadRequest struct {
 	InformationText string                `form:"informationText"`
 }
 
-/*
-	currently a no-op but enables us to add any custom form validation in
- 	without having to change any calling code
-*/
+
+// Currently a no-op but enables us to add any custom form validation in without having to change any calling code.
+
 func (req *UploadRequest) ValidateForm() error {
 	return nil
 }

--- a/backend/api/middlewares/auth.go
+++ b/backend/api/middlewares/auth.go
@@ -11,11 +11,11 @@ import (
 
 func AuthMiddleware() gin.HandlerFunc {
 	/*
-		do any initial setup for the middleware once here
+		Do any initial setup for the middleware once here
 
-		- load config value in case config management
-		- changes implementation where it could be a slow operation to fetch values
-		- like fetching over the net to a vault/secrets server
+		- Load config value in case config management
+		- Changes implementation where it could be a slow operation to fetch values
+		- Like fetching over the net to a vault/secrets server
 	*/
 	secret := config.Config().ApiSecret
 

--- a/backend/api/models/Composer.go
+++ b/backend/api/models/Composer.go
@@ -112,7 +112,7 @@ func (c *Composer) DeleteComposer(db *gorm.DB, composerName string) (int64, erro
 
 	confPath := path.Join(Config().ConfigPath, "sheets/uploaded-sheets/")
 
-	/* Move all files inside comp direcotry */
+	// Move all files inside comp direcotry
 	filepath.Walk(confPath+composerName,
 		func(path string, info os.FileInfo, err error) error {
 			if err != nil {
@@ -127,7 +127,7 @@ func (c *Composer) DeleteComposer(db *gorm.DB, composerName string) (int64, erro
 			return nil
 		})
 
-	/* Remove folder */
+	// Remove folder 
 	os.Remove(confPath + composerName)
 
 	return db.RowsAffected, nil
@@ -136,7 +136,7 @@ func (c *Composer) DeleteComposer(db *gorm.DB, composerName string) (int64, erro
 func (c *Composer) CreateUnknownComposer(db *gorm.DB) {
 
 	_, err := c.FindComposerBySafeName(db, "unknown")
-	/* Unknown doesn't exist yet */
+	// Unknown doesn't exist yet 
 	if err != nil {
 		c.Name = "Unknown"
 		c.SafeName = "unknown"
@@ -144,8 +144,7 @@ func (c *Composer) CreateUnknownComposer(db *gorm.DB) {
 		c.PortraitURL = "https://icon-library.com/images/unknown-person-icon/unknown-person-icon-4.jpg"
 		c.SaveComposer(db)
 
-		//Create a folder/directory at a full qualified path
-
+		// Create a folder/directory at a full qualified path
 		err := os.Mkdir(path.Join(Config().ConfigPath, "sheets/uploaded-sheets/unknown"), 0755)
 		if err != nil {
 			fmt.Println(err)
@@ -155,8 +154,8 @@ func (c *Composer) CreateUnknownComposer(db *gorm.DB) {
 }
 
 func (c *Composer) FindComposerBySafeName(db *gorm.DB, composerName string) (*Composer, error) {
-	/* Get information of one single composer */
-
+	
+	// Get information of one single composer
 	var err error
 	err = db.Model(&Composer{}).Where("safe_name = ?", composerName).Take(&c).Error
 	if err != nil {
@@ -182,10 +181,8 @@ func (c *Composer) GetAllComposer(db *gorm.DB) (*[]Composer, error) {
 }
 
 func (c *Composer) List(db *gorm.DB, pagination Pagination) (*Pagination, error) {
-	/*
-		For pagination
-	*/
 
+	// For pagination
 	var composers []*Composer
 	db.Scopes(paginate(composers, &pagination, db)).Find(&composers)
 	pagination.Rows = composers

--- a/backend/api/models/Sheet.go
+++ b/backend/api/models/Sheet.go
@@ -98,10 +98,8 @@ func (s *Sheet) GetAllSheets(db *gorm.DB) (*[]Sheet, error) {
 }
 
 func (s *Sheet) FindSheetBySafeName(db *gorm.DB, sheetName string) (*Sheet, error) {
-	/*
-		Get information of one single sheet by the safe sheet name
-	*/
 
+	// Get information of one single sheet by the safe sheet name
 	var err error
 	err = db.Model(&Sheet{}).Where("safe_sheet_name = ?", sheetName).Take(&s).Error
 
@@ -113,9 +111,8 @@ func (s *Sheet) FindSheetBySafeName(db *gorm.DB, sheetName string) (*Sheet, erro
 }
 
 func (s *Sheet) List(db *gorm.DB, pagination Pagination, composer string) (*Pagination, error) {
-	/*
-		For pagination
-	*/
+
+	// For pagination
 
 	var sheets []*Sheet
 	if composer != "" {
@@ -130,10 +127,8 @@ func (s *Sheet) List(db *gorm.DB, pagination Pagination, composer string) (*Pagi
 }
 
 func SearchSheet(db *gorm.DB, searchValue string) []*Sheet {
-	/*
-		Search for sheets with containing string
-	*/
 
+	// Search for sheets with containing string
 	var sheets []*Sheet
 	searchValue = "%" + searchValue + "%"
 	db.Where("sheet_name LIKE ?", searchValue).Find(&sheets)
@@ -141,27 +136,24 @@ func SearchSheet(db *gorm.DB, searchValue string) []*Sheet {
 }
 
 func ComposerEqual(composer string) func(db *gorm.DB) *gorm.DB {
-	/* Scope that composer is equal to composer (if you only want sheets from a certain composer) */
+
+	// Scope that composer is equal to composer (if you only want sheets from a certain composer)
 	return func(db *gorm.DB) *gorm.DB {
 		return db.Where("safe_composer = ?", composer)
 	}
 }
 
 func (s *Sheet) AppendTag(db *gorm.DB, appendTag string) {
-	/*
-		Append a new tag to a sheet
-	*/
 
+	// Append a new tag to a sheet
 	newArray := append(s.Tags, appendTag)
 
 	db.Model(&s).Update(Sheet{Tags: newArray})
 }
 
 func (s *Sheet) DelteTag(db *gorm.DB, value string) bool {
-	/*
-		Deleting a tag by it's value
-	*/
 
+	// Deleting a tag by it's value
 	index := utils.FindIndexByValue(s.Tags, value)
 
 	if index == -1 {

--- a/backend/api/models/User.go
+++ b/backend/api/models/User.go
@@ -13,7 +13,7 @@ import (
 )
 
 type User struct {
-	ID        uint32    `gorm:"primary_key;auto_increment" json:"id"` // if ID == 1: user = admin
+	ID        uint32    `gorm:"primary_key;auto_increment" json:"id"` // If ID == 1: user = admin
 	Nickname  string    `gorm:"size:255;not null;unique" json:"nickname"`
 	Email     string    `gorm:"size:100;not null;unique" json:"email"`
 	Password  string    `gorm:"size:100;not null;" json:"password"`

--- a/backend/api/utils/goUtils.go
+++ b/backend/api/utils/goUtils.go
@@ -1,18 +1,14 @@
 package utils
 
 func RemoveElementOfSlice(slice []string, index int) []string {
-	/*
-		Remove element of string slice by index
-	*/
 
+	// Remove element of string slice by index
 	return append(slice[:index], slice[index+1:]...)
 }
 
 func FindIndexByValue(slice []string, value string) int {
-	/*
-		Return Index of a specific value in a slice
-	*/
-
+	
+	// Return Index of a specific value in a slice
 	for p, v := range slice {
 		if v == value {
 			return p

--- a/backend/api/utils/pdfToImage.go
+++ b/backend/api/utils/pdfToImage.go
@@ -26,7 +26,7 @@ func sendRequest(path string, name string, remoteURL string) {
 
 	var client *http.Client
 	{
-		//setup a mocked http client.
+		// Setup a mocked http client.
 		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			b, err := httputil.DumpRequest(r, true)
 			if err != nil {
@@ -43,7 +43,7 @@ func sendRequest(path string, name string, remoteURL string) {
 	// Add InsecureSkipVerify because otherwise there would be an error
 	client.Transport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 
-	//prepare the reader instances to encode
+	// Prepare the reader instances to encode
 	values := map[string]io.Reader{
 		"file": mustOpen(path), // lets assume its this file
 		"name": strings.NewReader(name),
@@ -79,8 +79,10 @@ func Upload(client *http.Client, url string, values map[string]io.Reader, name s
 		}
 
 	}
-	// Don't forget to close the multipart writer.
-	// If you don't close it, your request will be missing the terminating boundary.
+	/* 
+		Don't forget to close the multipart writer.
+		If you don't close it, your request will be missing the terminating boundary.
+	*/
 	w.Close()
 
 	// Now that you have a form, you can submit it to your handler.


### PR DESCRIPTION
# Pull Request Template

## Description

This is a pull request intended to address the issue regarding the backend comments (18). 
I opted for changing all single line comments to:
```
// Comment
```
And to change all multiple lined comments to:
```
/*
    Comment 1
    Comment 2
*/
```
Fixes # (issue)

- https://github.com/SheetAble/SheetAble/issues/18

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings
