### PR TITLE
Fixed the Share button Link copy issue

### DIFF
--- a/frontend/src/Components/Sheet/Sheet.js
+++ b/frontend/src/Components/Sheet/Sheet.js
@@ -205,8 +205,11 @@ function Sheet({
   const [copyText, setCopyText] = useState("Click to Copy");
 
   const handleClick = () => {
-    setCopyText(copyText === "Click to Copy" ? "Copied ✓" : "Click to Copy");
-    navigator.clipboard.writeText(window.location.href);
+    navigator.clipboard.writeText(window.location.href).then(()=>{
+      setCopyText("Copied ✓")
+    }).catch(()=>{
+      setCopyText("Click to Copy")
+    });
   };
 
   const [editModal, setEditModal] = useState(false);


### PR DESCRIPTION
# Pull Request Template

## Description

Share button of sheet was not working. After clicking the share button the link was not getting copied to the clipboard.

Fixes # (issue)
"navigator.clipboard.writeText(window.location.href)" returns the promise which was not handled before, I fixed that by adding then and catch block and moved the setCopyText inside it.

## Type of change


Please delete options that are not relevant.

Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [✓] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [✓] My changes generate no new warnings
- [✓] I have checked my code and corrected any misspellings
