### PR TITLE
Updated Composer field to a multi-select dropdown to contain multiple composer names.

### DIFF
--- a/backend/api/forms/upload.go
+++ b/backend/api/forms/upload.go
@@ -14,6 +14,10 @@ type UploadRequest struct {
 
 // Currently a no-op but enables us to add any custom form validation in without having to change any calling code.
 
+func (req *UploadRequest) GetComposersAsSlice() []string {
+	return strings.Split(req.Composer, ", ")
+}
+
 func (req *UploadRequest) ValidateForm() error {
 	return nil
 }

--- a/frontend/src/Components/Upload/UploadPage.js
+++ b/frontend/src/Components/Upload/UploadPage.js
@@ -27,7 +27,7 @@ const InteractiveForm = () => {
 
   const [requestData, setrequestData] = useState({
     uploadFile: undefined,
-    composer: "",
+    composer: [], // Empty array to store multiple composer's names
     sheetName: "",
     releaseDate: "1999-12-31",
   });
@@ -45,10 +45,18 @@ const InteractiveForm = () => {
   };
 
   const handleChange = (event) => {
-    setrequestData({
-      ...requestData,
-      [event.target.name]: event.target.value,
-    });
+    if(event.target.name === "composer") {
+      const selectedComposers = Array.from(event.target.selectedOptions, option => option.value);
+      setrequestData({
+        ...requestData,
+        [event.target.name]: selectedComposers,
+      });
+    } else {
+      setrequestData({
+        ...requestData,
+        [event.target.name]: event.target.value,
+      });
+    }
   };
 
   return (

--- a/frontend/src/Redux/Actions/dataActions.js
+++ b/frontend/src/Redux/Actions/dataActions.js
@@ -203,7 +203,9 @@ export const uploadSheet = (data, _callback) => (dispatch) => {
   let bodyFormData = new FormData();
   bodyFormData.append("uploadFile", data.uploadFile);
   bodyFormData.append("sheetName", data.sheetName);
-  bodyFormData.append("composer", data.composer);
+  // Handling multiple composer names
+  const composerString = data.composer.join(', ');
+  bodyFormData.append("composer", composerString);
   bodyFormData.append("releaseDate", data.releaseDate);
 
   axios
@@ -230,7 +232,9 @@ export const updateSheet = (data, origSheetName, _callback) => (dispatch) => {
   let bodyFormData = new FormData();
   bodyFormData.append("uploadFile", data.uploadFile);
   bodyFormData.append("sheetName", data.sheetName);
-  bodyFormData.append("composer", data.composer);
+  // Handling multiple composer names
+  const composerString = data.composer.join(', ');
+  bodyFormData.append("composer", composerString);
   bodyFormData.append("releaseDate", data.releaseDate);
 
   axios


### PR DESCRIPTION
# Pull Request Template

## Description

I saw the issue posted by gorgobacka for the multiple artists for one song. I modified the composer field from an empty string to an empty array to store multiple composer names and created a multi-select dropdown. I then modified the handleChange and requestData functions in UploadPage.js to accept an array of strings. I then modified the uploadSheets and updateSheets functions in dataActions.js to support these changes. I added the function GetComposerAsSlice in upload.go so that the uploadRequest struct can split the composer string at the comma and space delimiter and return a slice of the composers' names. 

Fixes # (issue)

Fixes the issue posted by gorgobacka (#12). 

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings
