### PR TITLE
Updated ModalContent.js and UploadPage.js to restrict SheetName and Composer fields to 50 characters

### DIFF
--- a/frontend/src/Components/Sidebar/Modal/ModalContent.js
+++ b/frontend/src/Components/Sidebar/Modal/ModalContent.js
@@ -65,6 +65,7 @@ function ModalContent(props) {
           label="Sheet Name"
           className="form-field"
           name="sheetName"
+          inputProps={{ maxLength: 50 }}
           onChange={handleChange}
         />
         <TextField
@@ -72,6 +73,7 @@ function ModalContent(props) {
           label="Composer"
           className="form-field comp"
           name="composer"
+          inputProps={{ maxLength: 50 }}
           onChange={handleChange}
         />
       </form>

--- a/frontend/src/Components/Upload/UploadPage.js
+++ b/frontend/src/Components/Upload/UploadPage.js
@@ -83,6 +83,7 @@ const InteractiveForm = () => {
                   type="text"
                   class="name"
                   name="sheetName"
+                  maxlength="50"
                   placeholder="Sheet Name"
                   onChange={handleChange}
                 />
@@ -90,6 +91,7 @@ const InteractiveForm = () => {
                   type="text"
                   class="name"
                   name="composer"
+                  maxlength="50"
                   placeholder="Composer"
                   onChange={handleChange}
                 />


### PR DESCRIPTION
## Description
Added attributes to ModalContent.js and UploadPage.js that check for a maximum character length of 50 characters in the field entries.

Fixes #77

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
